### PR TITLE
Enhancement: Handle case where the number of peaks to be annotated is less than the entries in a partition

### DIFF
--- a/R/scATAC.Peak.annotation.R
+++ b/R/scATAC.Peak.annotation.R
@@ -542,12 +542,12 @@ peaks_closest_gene <- function(peaks, annotations=NULL, gene_element=NULL, TSSmo
   peaks_annotated <- peaks[peaks[,4] != "nomatch",]
   if ( TSSmode==T){
     cat("cbind_peaks_on_gene", "\n")
-    peaks_annotated_end <- peaks_annotated[grep("TSS",peaks_annotated[,6], invert = T),]
+    peaks_annotated_end <- peaks_annotated[grep("TSS",peaks_annotated[,6], invert = T), , drop=FALSE]
     peaks_annotated_end <- cbind(peaks_annotated_end, closest_downstream_gene=rep("",nrow(peaks_annotated_end)) ,closest_gene=rep("",nrow(peaks_annotated_end)),dist_clos_downstream=rep("",nrow(peaks_annotated_end)), dist_gene.edge_closest=rep("",nrow(peaks_annotated_end)))
     cat("cbind_peaks_on_TSS", "\n")
-    peaks_annotated_TSS_ol <- peaks_annotated[grep("TSS.overlap",peaks_annotated[,6]),]
+    peaks_annotated_TSS_ol <- peaks_annotated[grep("TSS.overlap",peaks_annotated[,6]), , drop=FALSE]
     peaks_annotated_TSS_ol <- cbind(peaks_annotated_TSS_ol, closest_downstream_gene=peaks_annotated_TSS_ol[,4],closest_gene=peaks_annotated_TSS_ol[,4], dist_clos_downstream=rep("",nrow(peaks_annotated_TSS_ol)),dist_gene.edge_closest=rep("",nrow(peaks_annotated_TSS_ol)))
-    peaks_annotated_TSS_on <- peaks_annotated[grep("TSS.dist",peaks_annotated[,6]),]
+    peaks_annotated_TSS_on <- peaks_annotated[grep("TSS.dist",peaks_annotated[,6]), , drop=FALSE]
     peaks_annotated_TSS_on <- cbind(peaks_annotated_TSS_on, closest_downstream_gene=peaks_annotated_TSS_on[,4],closest_gene=peaks_annotated_TSS_on[,4], dist_clos_downstream=rep("",nrow(peaks_annotated_TSS_on)),dist_gene.edge_closest=rep("",nrow(peaks_annotated_TSS_on)))
 
   }

--- a/R/scATAC.Peak.annotation.R
+++ b/R/scATAC.Peak.annotation.R
@@ -3,12 +3,19 @@ create_data_chunks <- function(data, chunk_size) {
   # data: matrix
   # chunk_size: integer
   data_list <- list()
-  # Handle case: nrow(peaks) < chunk_size
-  data_iterat <- max(1, nrow(data) %/% chunk_size)
-  default_warn <- getOption("warn")
-  options(warn = -1)
-  data_list <- split.data.frame(data, 1:data_iterat)
-  options(warn = default_warn)
+  # Handle case: nrow(data) < chunk_size
+  data_iterat <- nrow(data) %/% chunk_size
+  if (data_iterat > 0) {
+    for (n in 1:data_iterat) {
+      start <- n * chunk_size - (chunk_size - 1)
+      end <- min(n * chunk_size, nrow(data))
+      data_list[[n]] <- data[start:end, ]
+    }
+  }
+  if ((nrow(data) %% chunk_size) != 0) {
+    start <- length(data_list) * chunk_size + 1
+    data_list[[length(data_list) + 1]] <- data[start:nrow(data), ]
+  }
   return(data_list)
 }
 

--- a/R/scATAC.Peak.annotation.R
+++ b/R/scATAC.Peak.annotation.R
@@ -281,9 +281,12 @@ peaks_on_gene <- function(peak_features,annotations=NULL, gene_element=NULL, spl
   plan(multisession,workers = cores )
   peak_list <- list()
   computing <- cores*1000
+  # Handle case: nrow(peaks) < computing
   data_iterat <- nrow(peaks)%/%computing
-  for (n in 1:data_iterat) {
-    peak_list[[n]] <- peaks[(n*computing-(computing-1)):(n*computing),]
+  if (data_iterat > 0){
+    for (n in 1:data_iterat) {
+      peak_list[[n]] <- peaks[(n*computing-(computing-1)):(n*computing),]
+    }
   }
   if ((nrow(peaks) %% computing) != 0) {
     peak_list[[length(peak_list) +1 ]] <- peaks[(length(peak_list)*computing+1):nrow(peaks),]}

--- a/R/scATAC.Peak.annotation.R
+++ b/R/scATAC.Peak.annotation.R
@@ -20,21 +20,24 @@ create_data_chunks <- function(data, chunk_size) {
 }
 
 stardardize_chr_names <- function(peaks, annotation) {
-  # internal function
+  # internal function: prefix chromosome names with "chr" (UCSC convention)
   # peaks: matrix
   # annotation: data.frame
   chrom_peaks <- unique(peaks[, 1])
   chromosomes <- unique(as.character(annotation$seqnames))
   if (sum(chromosomes %in% chrom_peaks) == 0) {
     # check if chromosomes in annotations are only numeric + X, Y, MT
-    aux <- grepl("^[0-9XYMTxymt]+$", chromosomes, perl=TRUE)
+    aux <- grepl("^[0-9XYMTxymt]+$", chromosomes, perl=TRUE) 
     if (all(aux)) {
       annotation$seqnames <- paste0("chr", annotation$seqnames)
-      chromosomes <- unique(as.character(annotation$seqnames))
-    }
-    else{
+    } else {
       peaks[, 1] <- paste0("chr", peaks[, 1])
     }
+    # NOTE: Ensembl uses "MT" for mitochondrial genes, use "chrM" instead
+    annotation$seqnames <- sub("chrMT", "chrM", annotation$seqnames)
+    peaks[, 1] <- sub("chrMT", "chrM", peaks[, 1])
+    chromosomes <- unique(as.character(annotation$seqnames))
+    chrom_peaks <- unique(peaks[, 1])
     if (!all(chrom_peaks %in% chromosomes))
       stop("not all peak chromosome names are found in 'annotation'")
   }

--- a/R/scATAC.Peak.annotation.R
+++ b/R/scATAC.Peak.annotation.R
@@ -3,7 +3,7 @@ create_data_chunks <- function(data, chunk_size) {
   # data: data.frame
   # chunk_size: integer
   data_list <- list()
-  # Handle case: nrow(peaks) < computing
+  # Handle case: nrow(peaks) < chunk_size
   data_iterat <- max(1, nrow(data) %/% chunk_size)
   default_warn <- getOption("warn")
   options(warn = -1)

--- a/R/scATAC.Peak.annotation.R
+++ b/R/scATAC.Peak.annotation.R
@@ -291,9 +291,11 @@ peaks_on_gene <- function(peak_features,annotations=NULL, gene_element=NULL, spl
   if ((nrow(peaks) %% computing) != 0) {
     peak_list[[length(peak_list) +1 ]] <- peaks[(length(peak_list)*computing+1):nrow(peaks),]}
   peaks <- c()
-  cat("processing_",computing,"_rows_at_a_time", "\n")
+  cat("processing_", min(nrow(peak_list[[1]]), computing), "_rows_at_a_time", "\n", sep="")
+  n_processing <- 0
   for (n in 1:length(peak_list)) {
-    cat("processing_rows " , n*computing-(computing-1), " to ", n*computing, " ")
+    n_processing <- n_processing +  nrow(peak_list[[n]])
+    cat("processing_rows " , n*computing-(computing-1), " to ", min(n_processing, n*computing), " ")
     start_time <- Sys.time()
     peak_list[[n]] <- future.apply::future_lapply(seq_along(1:nrow(peak_list[[n]])), function(x, peak,chr_index) {
       chr <- peak[x,1]


### PR DESCRIPTION
Currently if the number of peaks to be annotated is less than the number of rows per partition, the function call will failed with a "subscript out of bounds" error.

Minor changes:
- Change names in annotation data.frame
- Check if chromosome in annotation are named following convention: chr + id