### PR TITLE
Use gene_id instead of gene_names

### DIFF
--- a/R/scATAC.Peak.annotation.R
+++ b/R/scATAC.Peak.annotation.R
@@ -325,8 +325,6 @@ peaks_on_gene <- function(peak_features,annotations=NULL, gene_element=NULL, spl
       mid1 <- gene_starts <= peak_start ### peak on the gene
       mid2 <- gene_ends >= peak_end
 
-      # NOTE: since equalities are allowed, make sure we don't annotate peaks
-      # redundantly (e.g., as peak on gene and also as gene-overlap)
       gene_left <- chr_index[[chr]][["gene_ids"]][left1 & left2]
       gene_right <- chr_index[[chr]][["gene_ids"]][right1 & right2]
       gene_mid <- chr_index[[chr]][["gene_ids"]][mid1 & mid2]

--- a/R/scATAC.Peak.annotation.R
+++ b/R/scATAC.Peak.annotation.R
@@ -318,21 +318,21 @@ peaks_on_gene <- function(peak_features,annotations=NULL, gene_element=NULL, spl
       peak_start <- as.numeric(peak[x,2])
       peak_end <- as.numeric(peak[x,3])
 
-      left1 <- gene_starts >= peak_start ### peak overlap left or span the whole gene
+      left1 <- gene_starts > peak_start ### peak overlap left or span the whole gene
       left2 <- gene_starts <= peak_end
       right1 <- gene_ends >= peak_start ### peak overlap right or span the whole gene
-      right2 <- gene_ends <= peak_end
+      right2 <- gene_ends < peak_end
       mid1 <- gene_starts <= peak_start ### peak on the gene
       mid2 <- gene_ends >= peak_end
 
       # NOTE: since equalities are allowed, make sure we don't annotate peaks
       # redundantly (e.g., as peak on gene and also as gene-overlap)
-      gene_left <- chr_index[[chr]][["gene_ids"]][(left1 & left2) & !(mid1 & mid2)]
-      gene_right <- chr_index[[chr]][["gene_ids"]][(right1 & right2) & !(mid1 & mid2)]
+      gene_left <- chr_index[[chr]][["gene_ids"]][left1 & left2]
+      gene_right <- chr_index[[chr]][["gene_ids"]][right1 & right2]
       gene_mid <- chr_index[[chr]][["gene_ids"]][mid1 & mid2]
       if (TSSmode) { #### ad distance here TSS here
         if ( length(gene_left) > 0  ) {
-          index <- which((left1 & left2) & !(mid1 & mid2))
+          index <- which(left1 & left2)
           gene_names <- chr_index[[chr]][["gene_names"]][index]
           distances <- chr_index[[chr]][["TSSset"]][index]
           distances <- strsplit(distances, "\\|")
@@ -343,7 +343,7 @@ peaks_on_gene <- function(peak_features,annotations=NULL, gene_element=NULL, spl
            gene_left <- sub("\\;-;TSS.overlap.dist.+", ";-;.;.;.", gene_left)
         } ### do also for right and mid
         if (length(gene_right) > 0) {
-          index <- which((right1 & right2) & !(mid1 & mid2))
+          index <- which(right1 & right2)
           gene_names <- chr_index[[chr]][["gene_names"]][index]
           distances <- chr_index[[chr]][["TSSset"]][index]
           distances <- strsplit(distances, "\\|")
@@ -397,8 +397,8 @@ peaks_on_gene <- function(peak_features,annotations=NULL, gene_element=NULL, spl
       }
       else{
         gene_ids <- c(gene_left, gene_right, gene_mid)
-        gene_names <- chr_index[[chr]][["gene_names"]][(left1 & left2) & !(mid1 & mid2)]
-        gene_names <- c(gene_names, chr_index[[chr]][["gene_names"]][(right1 & right2) & !(mid1 & mid2)])
+        gene_names <- chr_index[[chr]][["gene_names"]][left1 & left2]
+        gene_names <- c(gene_names, chr_index[[chr]][["gene_names"]][right1 & right2])
         gene_names <- c(gene_names, chr_index[[chr]][["gene_names"]][mid1 & mid2])
         if (length(gene_ids) > 1) {
             gene_names <- gene_names[!duplicated(gene_ids)]

--- a/R/scATAC.Peak.annotation.R
+++ b/R/scATAC.Peak.annotation.R
@@ -423,14 +423,16 @@ peaks_on_gene <- function(peak_features,annotations=NULL, gene_element=NULL, spl
   rownames(peak_ongene) <- paste0(peak_ongene[,1],":", peak_ongene[,2], "-", peak_ongene[,3])
   if (TSSmode==T){
     colnames(peak_ongene) <- c("seqnames", "Pstart", "Pend", "gene_id", "peak_on_gene", "strand", "TSSinfo", "TSSdistance", "overlap.alter.TSS")
+    # NOTE: peak length should only be return for TSSmode == T. This is because,
+    # TSS mode == F is designed to be used prior to give_activity
+    peaks_length <- apply(peak_ongene, 1, function(x) {
+      length(as.numeric(x[2]):as.numeric(x[3]))
+    })
+    peak_ongene<- cbind(peak_ongene, peaks_length=peaks_length)
   }
   else{
     colnames(peak_ongene) <- c("seqnames", "Pstart", "Pend", "gene_id", "peak_on_gene")
   }
-  peaks_length <- apply(peak_ongene, 1, function(x) {
-    length(as.numeric(x[2]):as.numeric(x[3]))
-  })
-  peak_ongene<- cbind(peak_ongene, peaks_length=peaks_length)
   end_time2 <- Sys.time()
   cat(paste("overall computing", "time", difftime(end_time2, start_time2, units="secs"), "s", "\n", sep = " "))
   plan(future::sequential)

--- a/R/scATAC.Peak.annotation.R
+++ b/R/scATAC.Peak.annotation.R
@@ -340,29 +340,31 @@ peaks_on_gene <- function(peak_features,annotations=NULL, gene_element=NULL, spl
       mid1 <- gene_starts <= peak_start ### peak on the gene
       mid2 <- gene_ends >= peak_end
 
-      gene_left <- chr_index[[chr]][["gene_names"]][left1 & left2]
-      gene_right <- chr_index[[chr]][["gene_names"]][right1 & right2]
+      # NOTE: since equalities are allowed, make sure we don't annotate peaks
+      # redundantly (e.g., as peak on gene and also as gene-overlap)
+      gene_left <- chr_index[[chr]][["gene_names"]][(left1 & left2) & !(mid1 & mid2)]
+      gene_right <- chr_index[[chr]][["gene_names"]][(right1 & right2) & !(mid1 & mid2)]
       gene_mid <- chr_index[[chr]][["gene_names"]][mid1 & mid2]
       if (TSSmode) { #### ad distance here TSS here
         if ( length(gene_left) > 0  ) {
-          index <- which(left1 & left2)
+          index <- which((left1 & left2) & !(mid1 & mid2))
           distances <- chr_index[[chr]][["TSSset"]][index]
           distances <- strsplit(distances, "\\|")
           distances <- lapply(distances, function(x) {as.numeric(x) - peak_start})
           distances <- lapply(distances, function(x) {paste(x, collapse = "|")})
           distances <- unlist(distances)
-          gene_left <- paste0(gene_left, "_",chr_index[[chr]][["strand"]][index],"_","TSS.overlap.dist.Pstart","_",as.character(distances),"_", ".")
+          gene_left <- paste0(gene_left, "_",chr_index[[chr]][["strand"]][index],"_","TSS.overlap.dist.Pstart.","_",as.character(distances),"_", ".")
           gene_left <- sub("\\_-_TSS.overlap.dist.+", "_-_._._.", gene_left)
         } ### do also for right and mid
         if (length(gene_right) > 0) {
-          index <- which(right1 & right2)
+          index <- which((right1 & right2) & !(mid1 & mid2))
           distances <- chr_index[[chr]][["TSSset"]][index]
           distances <- strsplit(distances, "\\|")
           distances <- lapply(distances, function(x) { peak_end - as.numeric(x) })
           distances <- lapply(distances, function(x) {paste(x, collapse = "|")})
           distances <- unlist(distances)
           gene_right <- paste0(gene_right, "_",chr_index[[chr]][["strand"]][index],"_" ,"TSS.overlap.dist.Pend.","_",as.character(distances), "_", ".")
-          gene_right <- sub("\\_+_TSS.overlap.dist.+", "_+_._._.", gene_right)
+          gene_right <- sub("_\\+_TSS.overlap.dist.+", "_+_._._.", gene_right)
         }
         if (length(gene_mid) > 0) {
           ### for alternative TSS


### PR DESCRIPTION
While trying to include non-protein-coding RNAs, I encountered some issues using `gene_name`s. These are not always unique and, sometimes, RNA's with the same `gene_name` can be located in different chromosomes, which won't work for combining all transcripts into one. I therefore propose to use `gene_id` to do the grouping and return both: `gene_name` and `gene_id`.
Also, some of the `gene_name`s contain underscores, that's why I am proposing to use semi-colon as the separator (see function `peaks_on_gene`)
This PR also includes some minor cosmetic changes